### PR TITLE
fix: Fix search word order: sort by length descending to avoid false mismatches

### DIFF
--- a/src/main/java/com/infomaximum/database/utils/PrefixIndexUtils.java
+++ b/src/main/java/com/infomaximum/database/utils/PrefixIndexUtils.java
@@ -251,6 +251,7 @@ public class PrefixIndexUtils {
         }
 
         int matchCount = 0;
+        sortedSearchingWords.sort(searchingWordComparator.reversed());
         for (String word : sortedSearchingWords) {
             for (int j = 0; j < tempList.size(); ++j) {
                 if (tempList.get(j).startsWith(word)) {

--- a/src/test/java/com/infomaximum/database/domainobject/engine/index/PrefixIndexUtilsTest.java
+++ b/src/test/java/com/infomaximum/database/domainobject/engine/index/PrefixIndexUtilsTest.java
@@ -157,6 +157,7 @@ public class PrefixIndexUtilsTest {
     @Test
     public void contains() {
         final String[] texts = {" Привет Медвед infom.COM COM  com  test...2d sop@ru \n \r", "ru.yandex perl"};
+        final String[] textsName = {"Андрей Абрамов Александрович"};
         List<String> tempList = new ArrayList<>();
 
         Assertions.assertThat(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("прив мед"), texts, tempList))
@@ -176,6 +177,14 @@ public class PrefixIndexUtilsTest {
         Assertions.assertThat(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords(" com ru 2d"), texts, tempList))
                 .isTrue();
         Assertions.assertThat(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords(" com ru yand"), texts, tempList))
+                .isTrue();
+        Assertions.assertThat(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("Андрей А"), textsName, tempList))
+                .isTrue();
+        Assertions.assertThat(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("А А"), textsName, tempList))
+                .isTrue();
+        Assertions.assertThat(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("А Андрей"), textsName, tempList))
+                .isTrue();
+        Assertions.assertThat(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("А Абрамов"), textsName, tempList))
                 .isTrue();
     }
 

--- a/src/test/java/com/infomaximum/database/domainobject/index/PrefixIndexUtilsTest.java
+++ b/src/test/java/com/infomaximum/database/domainobject/index/PrefixIndexUtilsTest.java
@@ -154,6 +154,7 @@ public class PrefixIndexUtilsTest {
     @Test
     public void contains() {
         final String[] texts = {" Привет Медвед infom.COM COM  com  test...2d sop@ru \n \r", "ru.yandex perl"};
+        final String[] textsName = {"Андрей Абрамов Александрович"};
         List<String> tempList = new ArrayList<>();
 
         Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("прив мед"), texts, tempList));
@@ -165,6 +166,10 @@ public class PrefixIndexUtilsTest {
         Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords(" com ru "), texts, tempList));
         Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords(" com ru 2d"), texts, tempList));
         Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords(" com ru yand"), texts, tempList));
+        Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("Андрей А"), textsName, tempList));
+        Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("А А"), textsName, tempList));
+        Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("А Андрей"), textsName, tempList));
+        Assert.assertTrue(PrefixIndexUtils.contains(PrefixIndexUtils.splitSearchingTextIntoWords("А Абрамов"), textsName, tempList));
     }
 
     private static void assertArrayEquals(long[] expected, byte[] actual) {


### PR DESCRIPTION
Task: PT-14849

Refs: https://jira.office.infomaximum.com/browse/PT-14849